### PR TITLE
Correction Bug FORCEDELTA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.lsc</groupId>
 	<artifactId>lsc-core</artifactId>
 	<name>LDAP Synchronization Connector</name>
-	<version>2.2.3</version>
+	<version>2.2.5</version>
 	<description>
 		This project is the LDAP Synchronization Connector which
 		simplifies synchronizations between relation databases and LDAP
@@ -814,6 +814,13 @@
 			<groupId>su.com.ibm.as400</groupId>
 			<artifactId>jt400</artifactId>
 			<version>JTOpen7.10</version>
+		</dependency>
+		
+		<!-- Dépendance pour gérer oracle -->
+		<dependency>
+		  <groupId>su.oracle.jdbc</groupId>
+		  <artifactId>ojdbc7</artifactId>
+		  <version>1.0.0</version>
 		</dependency>
 		
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.lsc</groupId>
 	<artifactId>lsc-core</artifactId>
 	<name>LDAP Synchronization Connector</name>
-	<version>2.2.2</version>
+	<version>2.2.3</version>
 	<description>
 		This project is the LDAP Synchronization Connector which
 		simplifies synchronizations between relation databases and LDAP
@@ -807,6 +807,13 @@
 			<groupId>su.org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<version>9.4-1201-jdbc41</version>
+		</dependency>
+		
+		<!-- Dépendance pour gérer l'interfaçage avec IBMi -->
+		<dependency>
+			<groupId>su.com.ibm.as400</groupId>
+			<artifactId>jt400</artifactId>
+			<version>JTOpen7.10</version>
 		</dependency>
 		
 	</dependencies>

--- a/src/main/java/org/lsc/beans/BeanComparator.java
+++ b/src/main/java/org/lsc/beans/BeanComparator.java
@@ -300,7 +300,7 @@ public final class BeanComparator {
             LscDatasetModification mi2 = null;
             switch (operationType) {
             case DELETE_VALUES:
-                if (attrStatus == PolicyType.FORCE) {
+                if (attrStatus == PolicyType.FORCE || attrStatus == PolicyType.FORCEDELTA) {
                     LOGGER.debug("{} Deleting attribute  \"{}\"", logPrefix, attrName);
                     mi = new LscDatasetModification(operationType, attrName, new HashSet<Object>());
                 }
@@ -311,7 +311,8 @@ public final class BeanComparator {
                 LOGGER.debug("{} Adding attribute \"{}\" with values {}",
                         new Object[] { logPrefix, attrName, toSetAttrValues });
 
-                if (modType != LscModificationType.CREATE_OBJECT && attrStatus == PolicyType.FORCE) {
+                if (modType != LscModificationType.CREATE_OBJECT
+                        && (attrStatus == PolicyType.FORCE || attrStatus == PolicyType.FORCEDELTA)) {
                     // By default, if we try to modify an attribute in
                     // the destination entry, we have to care to replace all
                     // values in the following conditions:

--- a/src/main/java/org/lsc/jndi/ScriptableJndiServices.java
+++ b/src/main/java/org/lsc/jndi/ScriptableJndiServices.java
@@ -199,6 +199,23 @@ public class ScriptableJndiServices extends ScriptableObject {
 
     /**
      * <P>
+     * Performs a search with subtree scope on a given base DN with a given filter returning attribute values
+     * </P>
+     *
+     * @param base
+     *            The base DN to search from.
+     * @attribute attribute The attribute to search.
+     * @return List<String> List of attributes values returned by the search.
+     * @throws NamingException
+     * @throws LscServiceException
+     */
+    public List<String> searchAttributeValues(Object base, Object attribute)
+            throws NamingException, LscServiceException {
+        return _searchAttributeValues((String) base, (String) attribute);
+    }
+
+    /**
+     * <P>
      * Performs a search with one level scope on a given base DN with a given filter returning attribute values
      * </P>
      *
@@ -222,7 +239,6 @@ public class ScriptableJndiServices extends ScriptableObject {
         List<String> attrsNames = new ArrayList<String>();
         attrsNames.add(attribute);
 
-        // Searching attributes values
         Map<String, LscDatasets> res = jndiServices.getAttrsList(base, filter, scope, attrsNames);
 
         for (Map.Entry<String, LscDatasets> entry : res.entrySet()) {
@@ -230,6 +246,14 @@ public class ScriptableJndiServices extends ScriptableObject {
         }
 
         return resAttributes;
+    }
+
+    protected List<String> _searchAttributeValues(String objectDn, String attribute)
+            throws NamingException, LscServiceException {
+
+        // Searching attributes values
+
+        return jndiServices.getAttributeValues(objectDn, attribute);
     }
 
     /**

--- a/src/main/java/org/lsc/service/SyncReplSourceService.java
+++ b/src/main/java/org/lsc/service/SyncReplSourceService.java
@@ -295,7 +295,7 @@ public class SyncReplSourceService extends SimpleJndiSrcService implements IAsyn
         Map<String, LscDatasets> temporaryMap = new HashMap<String, LscDatasets>(1);
         if (sf == null || sf.isCancelled()) {
             try {
-                searchRequest searchRequest = new SearchRequestImpl();
+                SearchRequest searchRequest = new SearchRequestImpl();
                 searchRequest.addControl(getSearchContinuationControl(srsc.getServerType()));
                 searchRequest.setBase(new Dn(getBaseDn()));
                 searchRequest.setFilter(getFilterAll());


### PR DESCRIPTION
Correction d'un bug de synchronisation en mode FORCEDELTA --> 
Lors de la synchronisation de champs multivalués en mode FORCEDELTA, lorsque la source est une liste avec plusieurs valeurs et la destination une liste sans valeur, la mise à jour ne fonctionne pas.


Création d'un nouvelle possibilité de recherche ldap via les scripts js : searchAttributeValues . Permet de rechercher la liste de valeurs d'un champ multivalué
 